### PR TITLE
Version assets and add changelog

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 .DS_Store
 .git/
+AGENTS.md
 uploads/
 node_modules/
 test-results/

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,38 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/).
+
+## [1.0.1] - 2026-07-16
+
+### Added
+
+- Project changelog following the Keep a Changelog format.
+
+### Changed
+
+- Versioned local asset URLs using the package version for reliable cache invalidation after deployments.
+
+## [1.0.0] - 2026-07-16
+
+### Added
+
+- Initial release of QRTurbo.app.
+- Fully client-side QR code generation with no tracking, advertisements, or data uploads.
+- Support for URL and text, vCard, MeCard, Wi-Fi, SMS, phone, email, calendar event, location, social media, WhatsApp, and app-link QR codes.
+- QR code customization with foreground and background colors, transparent backgrounds, logos, dot and corner styles, quiet-zone controls, multiple sizes, and error-correction levels.
+- Export to PNG, SVG, and PDF.
+- Light and dark themes.
+- User interface translations for 12 languages.
+- Offline use through Progressive Web App support.
+- Responsive and accessible interface for desktop and mobile devices.
+- Privacy policy, terms of use, and third-party license notices.
+- Automated unit, static, accessibility, browser, artifact, and PWA tests.
+
+### Security
+
+- QR code contents and uploaded logos are processed entirely in the browser.
+- Input validation and scannability warnings for potentially unreliable QR code configurations.
+- Sensitive QR payloads are excluded from exported PDF documents.

--- a/Public/index.html
+++ b/Public/index.html
@@ -67,11 +67,11 @@
     </script>
 
     <!-- Favicon Configuration -->
-    <link rel="icon" type="image/png" sizes="192x192" href="/android-chrome-192x192.png">
-    <link rel="icon" type="image/png" sizes="512x512" href="/android-chrome-512x512.png">
-    <link rel="apple-touch-icon" sizes="180x180" href="/apple-touch-icon.png">
-    <link rel="icon" href="/favicon.ico" type="image/x-icon">
-    <link rel="manifest" href="/manifest.json">
+    <link rel="icon" type="image/png" sizes="192x192" href="/android-chrome-192x192.png?v=1.0.1">
+    <link rel="icon" type="image/png" sizes="512x512" href="/android-chrome-512x512.png?v=1.0.1">
+    <link rel="apple-touch-icon" sizes="180x180" href="/apple-touch-icon.png?v=1.0.1">
+    <link rel="icon" href="/favicon.ico?v=1.0.1" type="image/x-icon">
+    <link rel="manifest" href="/manifest.json?v=1.0.1">
     <script>
         try {
             const savedTheme = localStorage.getItem('qrturbo_theme');
@@ -83,7 +83,7 @@
         }
     </script>
     <!-- Local CSS -->
-    <link rel="stylesheet" href="css/styles.css">
+    <link rel="stylesheet" href="css/styles.css?v=1.0.1">
 </head>
 
 <body>
@@ -578,9 +578,9 @@
     </footer>
 
     <!-- External JavaScript -->
-    <script src="js/i18n/core.js" defer></script>
-    <script src="js/qr-code-styling.min.js" defer></script>
-    <script src="js/app.js" defer></script>
+    <script src="js/i18n/core.js?v=1.0.1" defer></script>
+    <script src="js/qr-code-styling.min.js?v=1.0.1" defer></script>
+    <script src="js/app.js?v=1.0.1" defer></script>
 </body>
 
 </html>

--- a/Public/js/app.js
+++ b/Public/js/app.js
@@ -8,6 +8,7 @@ let activeGenerationPromise = null;
 const THEME_STORAGE_KEY = 'qrturbo_theme';
 const DEFAULT_THEME = 'light';
 const AUTO_PREVIEW_DELAY = 450;
+const ASSET_VERSION_QUERY = document.currentScript?.src.match(/\?v=[^#&]+/)?.[0] || '';
 const WHATSAPP_USERNAME_PATTERN = /^@(?![0-9]{3,35}$)[a-z0-9._]{3,35}$/;
 const WHATSAPP_PHONE_PATTERN = /^\+?[0-9\s().-]+$/;
 const MIN_QUIET_ZONE_MODULES = 4;
@@ -57,7 +58,7 @@ function registerServiceWorker() {
     }
 
     window.addEventListener('load', () => {
-        navigator.serviceWorker.register('/sw.js').catch(error => {
+        navigator.serviceWorker.register(`/sw.js${ASSET_VERSION_QUERY}`).catch(error => {
             console.warn('Service worker registration failed:', error);
         });
     });

--- a/Public/js/i18n/core.js
+++ b/Public/js/i18n/core.js
@@ -4,6 +4,7 @@
 
 // Current language (default: English)
 let currentLang = 'en';
+const assetVersionQuery = document.currentScript?.src.match(/\?v=[^#&]+/)?.[0] || '';
 
 // Translation database (English embedded, others lazy-loaded)
 // Expose on window so locale files can register their translations
@@ -354,7 +355,7 @@ async function loadLanguage(langCode) {
   // Create loading promise
   const loadPromise = new Promise((resolve, reject) => {
     const script = document.createElement('script');
-    script.src = `js/i18n/locales/${langCode}.js`;
+    script.src = `js/i18n/locales/${langCode}.js${assetVersionQuery}`;
     script.async = true;
 
     script.onload = () => {

--- a/Public/sw.js
+++ b/Public/sw.js
@@ -1,6 +1,6 @@
 // The hash suffix fingerprints every entry in PRECACHE_URLS. The PWA integrity
 // test intentionally fails when a precached file changes without a new suffix.
-const CACHE_VERSION = 'v5-922296ad70d8';
+const CACHE_VERSION = 'v5-1d33ad336fe8';
 const STATIC_CACHE = `qrturbo-static-${CACHE_VERSION}`;
 
 const PRECACHE_URLS = [

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "qrturbo.app",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "qrturbo.app",
-      "version": "1.0.0",
+      "version": "1.0.1",
       "engines": {
         "node": ">=22.5.0"
       },

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "qrturbo.app",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "private": true,
   "type": "commonjs",
   "engines": {

--- a/tests/static/site-integrity.test.js
+++ b/tests/static/site-integrity.test.js
@@ -25,12 +25,30 @@ function assertPublicAssetExists(assetPath) {
     return;
   }
 
-  const normalized = assetPath.replace(/^\//, '');
+  const normalized = assetPath.replace(/^\//, '').split(/[?#]/, 1)[0];
   assert.ok(
     fs.existsSync(path.join(publicDir, normalized)),
     `Expected public asset to exist: ${assetPath}`
   );
 }
+
+test('index asset URLs use the package version as their cache key', () => {
+  const html = readPublicFile('index.html');
+  const { version } = JSON.parse(fs.readFileSync(path.join(repoRoot, 'package.json'), 'utf8'));
+  const localAssets = [
+    ...extractAttributeValues(html, 'src'),
+    ...extractAttributeValues(html, 'href')
+  ].filter(assetPath => /^(?:\/|css\/|js\/).+\.(?:css|ico|js|json|png)(?:\?|$)/.test(assetPath));
+
+  assert.ok(localAssets.length > 0, 'Expected index.html to reference local assets');
+  for (const assetPath of localAssets) {
+    assert.equal(
+      new URL(assetPath, 'https://qrturbo.test').searchParams.get('v'),
+      version,
+      `Asset URL must use package version ${version}: ${assetPath}`
+    );
+  }
+});
 
 test('HTML references only existing local scripts, styles, icons and manifest assets', () => {
   const html = readPublicFile('index.html');


### PR DESCRIPTION
## Summary
- add a Keep a Changelog-formatted project changelog
- use package-versioned asset URLs for cache invalidation
- keep package, asset, and service worker cache versions synchronized

## Tests
- npm run test:fast
- npm run test:coverage